### PR TITLE
Reinstate the DATADOG_API constant.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,13 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/fimmti
 
 * Signal deploys going out with a happy goat sound.
 
+```
+dd.stream(start_at, end_at, tags: ["env:production", "event_type:deploy", "region:prod_us_a"])[1]["events"].count
+```
+
 * Take non-peak times into account instead of going crazy at the end of the day.
+
+* Support EU, CA, and Grow. (Currently only supports Manage PROD-US.)
 
 * Shark attack at the end of the demo
 

--- a/lib/clio_audio_visualizer.rb
+++ b/lib/clio_audio_visualizer.rb
@@ -1,6 +1,6 @@
-require "clio_audio_visualizer/version"
 require "dotenv/load"
 
+require "clio_audio_visualizer/version"
 require "clio_audio_visualizer/metrics/metric"
 require "clio_audio_visualizer/metrics/file_reader"
 require "clio_audio_visualizer/metrics/datadog_reader"
@@ -8,4 +8,5 @@ require "clio_audio_visualizer/metrics/writer"
 require "clio_audio_visualizer/metrics/loader"
 
 module ClioAudioVisualizer
+  DATADOG_API = Dogapi::Client.new(ENV['DATADOG_API_KEY'], ENV['DATADOG_APPLICATION_KEY'])
 end

--- a/lib/clio_audio_visualizer/metrics/datadog_reader.rb
+++ b/lib/clio_audio_visualizer/metrics/datadog_reader.rb
@@ -2,8 +2,6 @@ require "dogapi"
 
 module Metrics
   class DatadogReader < Metric
-    DATADOG_API = Dogapi::Client.new(ENV['DATADOG_API_KEY'], ENV['DATADOG_APPLICATION_KEY'])
-
     def read_data(from, to)
       DATADOG_API.get_points(datadog_query, from, to)
     end


### PR DESCRIPTION
Turns out we'll need it in more than one place after all! Whoops.